### PR TITLE
(docs): fixed link to MAXREFDES178 getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the home for IC, EV Kit, SDK, and AI documentation for the Maxim AI prod
 
 ->->-> **[Getting Started with the MAX78000 Feather Board](./MAX78000_Feather/README.md)**
 
-->->-> **[Getting Started with the MAXREFDES178# Cube Camera](https://github.com/MaximIntegratedAI/refdes/blob/main/maxrefdes178)**
+->->-> **[Getting Started with the MAXREFDES178# Cube Camera](https://github.com/MaximIntegratedAI/refdes/blob/main/maxrefdes178_doc/README.md)**
 
 -----
 - [Maxim AI Documentation](#maxim-ai-documentation)
@@ -26,19 +26,19 @@ The project consists of five repositories:
 
 2. The software development kit (SDK), which contains peripheral drivers and example programs ready to run on the Evaluation Kit:
    [MAX78000_SDK](https://github.com/MaximIntegratedAI/MAX78000_SDK). See [here](https://www.maximintegrated.com/en/design/technical-documents/userguides-and-manuals/7/7219.html) for the most recent SDK Installation Guide.
-   
+
 3. The training repo, which is used for deep learning model development and training:
    [ai8x-training](https://github.com/MaximIntegratedAI/ai8x-training)
-   
+
 4. The synthesis repo, which is used to convert a trained model into C code using the “izer” tool:
    [ai8x-synthesis](https://github.com/MaximIntegratedAI/ai8x-synthesis)
-   
+
 5. The reference design repo, which contains application code and documentation for the reference designs:
    [refdes](https://github.com/MaximIntegratedAI/refdes)
 
-   
 
-## Links to MAX78000 Documentation 
+
+## Links to MAX78000 Documentation
 
 * Link to IC description and datasheet: [MAX78000](https://www.maximintegrated.com/en/products/microcontrollers/MAX78000.html)
 * Link to IC User Guide: [MAX78000 User Guide.pdf](https://pdfserv.maximintegrated.com/en/an/ug7456.pdf)
@@ -48,12 +48,12 @@ The project consists of five repositories:
 * Link to Feather Board description and documentation: [MAX78000 Feather Board](https://www.maximintegrated.com/en/products/microcontrollers/MAX78000FTHR.html)
 * Link to SDK repository: [MAX78000_SDK](https://github.com/MaximIntegratedAI/MAX78000_SDK)
 * Link to SDK documentation: [SDK Docs - click on index.html](https://github.com/MaximIntegratedAI/MAX78000_SDK/blob/master/Libraries/PeriphDrivers/Documentation/MAX78000)  **Note:** HTML files are not rendered in GitHub and it is therefore recommended to view the SDK documentation from a local copy, which is automatically installed with the SDK.  To view the SDK documentation locally, double click on the index.html file found in /Libraries/PeriphDrivers/Documentation/MAX78000
-* Link to Reference Design documentation and reference design application code repository: [MAX78000 Reference Designs](https://github.com/MaximIntegratedAI/refdes) 
+* Link to Reference Design documentation and reference design application code repository: [MAX78000 Reference Designs](https://github.com/MaximIntegratedAI/refdes)
 * Quick Start Guides and Optional Features: [Guides](Guides)
 
 ## Application Notes
 
-1. [Developing Power-optimized Applications on the MAX78000](https://www.maximintegrated.com/en/design/technical-documents/app-notes/7/7417.html): 
+1. [Developing Power-optimized Applications on the MAX78000](https://www.maximintegrated.com/en/design/technical-documents/app-notes/7/7417.html):
 
    Abstract: Power consumption is a key factor for edge Artificial Intelligence (AI) applications where the entire system is powered by small battery cells and is expected to operate for months without recharging or replacing the batteries. The MAX78000 ultra-low power AI microcontroller is built to target such applications at the edge of the IoT. In this document, various configurations are described to enable users to develop power-optimized applications on the MAX78000, along with benchmarking examples. The power optimization methods are applied to two case study applications—Keyword Spotting with 20 keywords (KWS20) and Face Identification (FaceID), and the reported results can be used as a guideline for the user’s application.
 
@@ -65,7 +65,7 @@ The project consists of five repositories:
 
    Abstract: Audio assistants have become very popular with range of applications from household to automotive and industrial products and IoT. Such devices constantly listen to their surroundings and wake up on pretrained keywords to execute certain commands. Power consumption is a key factor for many of such resource constrained edge applications, where the connectivity to the cloud for processing of raw data is not feasibly. The MAX78000 is a new breed of Artificial Intelligence (AI) microcontroller built to enable neural networks to execute at ultra-low power and live at the edge of the IoT. In this document, we show case the implementation of a keyword spotting application on the MAX78000. The machine learning model is built with Maxim’s development flow on PyTorch, trained with a subset of Google’s speech command dataset with 20 keywords, and deployed on the MAX78000EVKIT.
 
-   
+
 
 ## Additional MAX78000 and Machine Learning Education Resources
 


### PR DESCRIPTION
The link for "Getting Started with the MAXREFDES178# Cube Camera" currently points to https://github.com/MaximIntegratedAI/refdes/blob/main/maxrefdes178 which returns 404.

The updated link points to https://github.com/MaximIntegratedAI/refdes/blob/main/maxrefdes178_doc/README.md which is a document titled "Getting Started with the MAXREFDES178# Cube Camera"